### PR TITLE
Add HPS household register support and update enrollment logic.

### DIFF
--- a/opensrp-chw-core/src/main/java/org/smartregister/chw/core/CoreHpsRegisterFragment.java
+++ b/opensrp-chw-core/src/main/java/org/smartregister/chw/core/CoreHpsRegisterFragment.java
@@ -150,15 +150,30 @@ public class CoreHpsRegisterFragment extends BaseHpsRegisterFragment {
     public void countExecute() {
         Cursor c = null;
         try {
+            String query = "";
+            if (presenter().getMainTable() != null) {
+                if (presenter().getMainTable().equalsIgnoreCase(CoreConstants.TABLE_NAME.HPS_MEMBERS)) {
+                    query = "select count(*) from " + presenter().getMainTable() + " inner join " + CoreConstants.TABLE_NAME.FAMILY_MEMBER +
+                            " on " + presenter().getMainTable() + "." + DBConstants.KEY.BASE_ENTITY_ID + " = " +
+                            CoreConstants.TABLE_NAME.FAMILY_MEMBER + "." + DBConstants.KEY.BASE_ENTITY_ID +
+                            " where " + presenter().getMainCondition();
 
-            String query = "select count(*) from " + presenter().getMainTable() + " inner join " + CoreConstants.TABLE_NAME.FAMILY_MEMBER +
-                    " on " + presenter().getMainTable() + "." + DBConstants.KEY.BASE_ENTITY_ID + " = " +
-                    CoreConstants.TABLE_NAME.FAMILY_MEMBER + "." + DBConstants.KEY.BASE_ENTITY_ID +
-                    " where " + presenter().getMainCondition();
+                    if (StringUtils.isNotBlank(filters)) {
+                        query = query + " and ( " + filters + " ) ";
+                    }
+                } else if (presenter().getMainTable().equalsIgnoreCase(CoreConstants.TABLE_NAME.HPS_HOUSEHOLD)) {
+                    query = "select count(*) from " + presenter().getMainTable() + " inner join " + CoreConstants.TABLE_NAME.FAMILY +
+                            " on " + presenter().getMainTable() + "." + DBConstants.KEY.BASE_ENTITY_ID + " = " +
+                            CoreConstants.TABLE_NAME.FAMILY + "." + DBConstants.KEY.BASE_ENTITY_ID +
+                            " where " + presenter().getMainCondition();
 
-            if (StringUtils.isNotBlank(filters)) {
-                query = query + " and ( " + filters + " ) ";
+                    if (StringUtils.isNotBlank(filters)) {
+                        query = query + " and ( " + filters + " ) ";
+                    }
+                }
             }
+
+
 
 
             c = commonRepository().rawCustomQueryForAdapter(query);

--- a/opensrp-chw-core/src/main/java/org/smartregister/chw/core/activity/CoreFamilyProfileActivity.java
+++ b/opensrp-chw-core/src/main/java/org/smartregister/chw/core/activity/CoreFamilyProfileActivity.java
@@ -112,7 +112,7 @@ public abstract class CoreFamilyProfileActivity extends BaseFamilyProfileActivit
         if (i == R.id.action_family_details) {
             startFormForEdit();
         } else if (i == R.id.action_hps_enrollment) {
-            startHpsHouseholdEnrollment(familyHead);
+            startHpsHouseholdEnrollment(familyBaseEntityId);
         } else if (i == R.id.action_remove_member) {
             Intent frm_intent = new Intent(this, getFamilyRemoveMemberClass());
             frm_intent.putExtra(Constants.INTENT_KEY.FAMILY_BASE_ENTITY_ID, getFamilyBaseEntityId());

--- a/opensrp-chw-core/src/main/java/org/smartregister/chw/core/utils/CoreConstants.java
+++ b/opensrp-chw-core/src/main/java/org/smartregister/chw/core/utils/CoreConstants.java
@@ -956,6 +956,7 @@ public class CoreConstants {
         public static final String LTFU_REFERRALS = "ec_ltfu_referrals";
         public static final String ADDO_LINKAGE = "ec_addo_linkage";
         public static final String HPS_MEMBERS = "ec_hps_client_register";
+        public static final String HPS_HOUSEHOLD = "ec_hps_household_register";
     }
 
     public static final class INTENT_KEY {


### PR DESCRIPTION
- Define `HPS_HOUSEHOLD` table constant in `CoreConstants`.
- Update `CoreHpsRegisterFragment` to support count queries for both HPS members and HPS households.
- Fix HPS household enrollment in `CoreFamilyProfileActivity` to use `familyBaseEntityId` instead of `familyHead`.