### PR TITLE
fix: correct harm reduction enrollment wording

### DIFF
--- a/opensrp-chw-core/src/main/res/values-sw/strings.xml
+++ b/opensrp-chw-core/src/main/res/values-sw/strings.xml
@@ -733,7 +733,7 @@
     <string name="tb_registration">Usajili wa TB</string>
     <string name="tbleprosy_screening">Uchunguzi wa awali wa Kifua Kikuu na Ukoma</string>
     <string name="tbleprosy_screening_info">Matokeo ya uchunguzi wa awali wa Kifua Kikuu na Ukoma</string>
-    <string name="harm_reduction_risk_assessment">Usajili wa huduma za kunguza madhara ya madawa ya kulevya</string>
+    <string name="harm_reduction_risk_assessment">Usajili wa huduma za kupunguza madhara ya madawa ya kulevya</string>
     <string name="harm_reduction_sober_house_enrollment">Usajili wa huduma za Upataji Nafuu</string>
     <string name="remove_client">Ondoa mteja</string>
     <string name="call_all_clients_member">Piga simu kwa mteja au mlezi</string>

--- a/opensrp-chw-core/src/test/java/org/smartregister/chw/core/forms/HarmReductionStringResourcesTest.java
+++ b/opensrp-chw-core/src/test/java/org/smartregister/chw/core/forms/HarmReductionStringResourcesTest.java
@@ -1,0 +1,39 @@
+package org.smartregister.chw.core.forms;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class HarmReductionStringResourcesTest {
+
+    @Test
+    public void testSwahiliEnrollmentStringUsesKupunguza() throws Exception {
+        String stringsXml = readText("src/main/res/values-sw/strings.xml");
+
+        Assert.assertTrue(stringsXml.contains("<string name=\"harm_reduction_risk_assessment\">Usajili wa huduma za kupunguza madhara ya madawa ya kulevya</string>"));
+        Assert.assertFalse(stringsXml.contains("Usajili wa huduma za kunguza madhara ya madawa ya kulevya"));
+    }
+
+    private static String readText(String relativePath) throws IOException {
+        return new String(Files.readAllBytes(resolvePath(relativePath)), StandardCharsets.UTF_8);
+    }
+
+    private static Path resolvePath(String relativePath) {
+        Path direct = Paths.get(relativePath);
+        if (Files.exists(direct)) {
+            return direct;
+        }
+
+        Path modulePath = Paths.get("opensrp-chw-core").resolve(relativePath);
+        if (Files.exists(modulePath)) {
+            return modulePath;
+        }
+
+        throw new AssertionError("Could not resolve path: " + relativePath);
+    }
+}


### PR DESCRIPTION
## Summary
- correct the Swahili Harm Reduction enrollment wording from "kunguza" to "kupunguza"
- add a focused file-based regression test for the core string resource

## Testing
- ./gradlew :opensrp-chw-core:testDebugUnitTest --tests org.smartregister.chw.core.forms.HarmReductionStringResourcesTest
- blocked in this environment by GitHub Packages dependency resolution for org.smartregister:opensrp-client-chw-malaria:2.0.1-NACP-SNAPSHOT (401 Unauthorized)

Fixes Digital-Square-Tanzania/opensrp-client-chw#773