### PR TITLE
Fix indicator generation worker scheduling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,16 +121,16 @@ task jacocoTestReport(type: JacocoReport) {
 
     reports {
         html {
-            html.enabled = true
-            destination file("${buildDir}/reports/jacoco/jacocoRootReport/jacocoFullReport")
+            required.set(true)
+            outputLocation.set(file("${buildDir}/reports/jacoco/jacocoRootReport/jacocoFullReport"))
         }
 
         xml {
-            xml.enabled = true
-            destination file("${buildDir}/reports/jacoco/jacocoRootReport/jacocoFullReport.xml")
+            required.set(true)
+            outputLocation.set(file("${buildDir}/reports/jacoco/jacocoRootReport/jacocoFullReport.xml"))
         }
 
-        csv.enabled = false
+        csv.required.set(false)
     }
     onlyIf {
         executionData.files.any { it.exists() }

--- a/opensrp-chw-core/build.gradle
+++ b/opensrp-chw-core/build.gradle
@@ -861,12 +861,12 @@ dependencies {
 task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
 
     reports {
-        xml.enabled = true
-        html.enabled = true
+        xml.required.set(true)
+        html.required.set(true)
     }
 
-    getReports().getXml().setDestination(file("${buildDir}/reports/jacoco/jacocoRootReport/merged.xml"))
-    getReports().getHtml().setDestination(file("${buildDir}/reports/jacoco/jacocoRootReport/html"))
+    getReports().getXml().getOutputLocation().set(file("${buildDir}/reports/jacoco/jacocoRootReport/merged.xml"))
+    getReports().getHtml().getOutputLocation().set(file("${buildDir}/reports/jacoco/jacocoRootReport/html"))
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*', '**/*$ViewBinder*.*']
     def debugTree = fileTree(dir: "$project.buildDir/intermediates/javac/debug/classes", excludes: fileFilter)

--- a/opensrp-chw-core/src/main/java/org/smartregister/chw/core/job/ChwIndicatorGeneratingJob.java
+++ b/opensrp-chw-core/src/main/java/org/smartregister/chw/core/job/ChwIndicatorGeneratingJob.java
@@ -2,6 +2,9 @@ package org.smartregister.chw.core.job;
 
 import androidx.annotation.NonNull;
 
+import org.smartregister.chw.core.application.CoreChwApplication;
+import org.smartregister.chw.core.worker.ReportIndicatorGeneratingWorker;
+import org.smartregister.job.BaseWorker;
 import org.smartregister.reporting.job.RecurringIndicatorGeneratingJob;
 
 /**
@@ -14,6 +17,22 @@ import org.smartregister.reporting.job.RecurringIndicatorGeneratingJob;
  */
 @Deprecated
 public class ChwIndicatorGeneratingJob extends RecurringIndicatorGeneratingJob {
+    public static void scheduleJob(String jobTag, Long start, Long flex) {
+        BaseWorker.scheduleJob(
+                CoreChwApplication.getInstance().getApplicationContext(),
+                jobTag,
+                start,
+                flex,
+                ReportIndicatorGeneratingWorker.class);
+    }
+
+    public static void scheduleJobImmediately(String jobTag) {
+        BaseWorker.scheduleJobImmediately(
+                CoreChwApplication.getInstance().getApplicationContext(),
+                jobTag,
+                ReportIndicatorGeneratingWorker.class);
+    }
+
     @NonNull
     protected Result onRunJob(@NonNull Params params) {
         return super.onRunJob(params);

--- a/opensrp-chw-core/src/main/java/org/smartregister/chw/core/worker/ReportIndicatorGeneratingWorker.java
+++ b/opensrp-chw-core/src/main/java/org/smartregister/chw/core/worker/ReportIndicatorGeneratingWorker.java
@@ -1,15 +1,21 @@
 package org.smartregister.chw.core.worker;
 
-import android.app.PendingIntent;
 import android.content.Context;
-import android.content.Intent;
 
 import androidx.annotation.NonNull;
 import androidx.work.WorkerParameters;
 
 import org.smartregister.AllConstants;
 import org.smartregister.job.BaseWorker;
-import org.smartregister.reporting.service.IndicatorGeneratorIntentService;
+import org.smartregister.reporting.ReportingLibrary;
+import org.smartregister.reporting.dao.ReportIndicatorDaoImpl;
+import org.smartregister.reporting.domain.TallyStatus;
+import org.smartregister.reporting.event.EventBusHelper;
+import org.smartregister.reporting.event.IndicatorTallyEvent;
+import org.smartregister.reporting.repository.DailyIndicatorCountRepository;
+import org.smartregister.reporting.repository.IndicatorQueryRepository;
+import org.smartregister.reporting.repository.IndicatorRepository;
+import org.smartregister.repository.AllSharedPreferences;
 
 import timber.log.Timber;
 
@@ -27,19 +33,7 @@ public class ReportIndicatorGeneratingWorker extends BaseWorker {
 
     @Override
     protected JobResult onRunJob(@NonNull Params params) {
-        // Create an intent to start the IndicatorGeneratorIntentService
-        Intent intent = new Intent(getApplicationContext(), IndicatorGeneratorIntentService.class);
-
-        // Create a PendingIntent with appropriate flags
-        PendingIntent pendingIntent = createPendingIntent(getApplicationContext(), intent);
-
-        // Execute the pending intent using the BaseWorker helper method
-        boolean executed = executePendingIntent(pendingIntent);
-        if (executed) {
-            Timber.d("IndicatorGeneratorIntentService started successfully via PendingIntent.");
-        } else {
-            Timber.e("Failed to execute PendingIntent for IndicatorGeneratorIntentService.");
-        }
+        generateIndicatorTallies();
 
         // Determine if the job should be rescheduled based on the extras.
         boolean toReschedule = params.getExtras().getBoolean(AllConstants.INTENT_KEY.TO_RESCHEDULE, false);
@@ -47,15 +41,37 @@ public class ReportIndicatorGeneratingWorker extends BaseWorker {
         return toReschedule ? JobResult.RESCHEDULE : JobResult.SUCCESS;
     }
 
-    /**
-     * Helper method to create a PendingIntent for starting a service.
-     *
-     * @param context the application context.
-     * @param intent  the Intent used to start the service.
-     * @return a PendingIntent configured with the correct flags.
-     */
-    private PendingIntent createPendingIntent(Context context, Intent intent) {
-        int flags = PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE;
-        return PendingIntent.getService(context, 0, intent, flags);
+    private void generateIndicatorTallies() {
+        Timber.i("ReportIndicatorGeneratingWorker running");
+
+        ReportingLibrary reportingLibrary = ReportingLibrary.getInstance();
+        AllSharedPreferences allSharedPreferences = reportingLibrary.getContext().allSharedPreferences();
+        String lastProcessedDate = allSharedPreferences.getPreference(ReportIndicatorDaoImpl.REPORT_LAST_PROCESSED_DATE);
+        Timber.d("LastProcessedDate %s", lastProcessedDate);
+
+        EventBusHelper.postEvent(new IndicatorTallyEvent(TallyStatus.STARTED));
+
+        IndicatorTallyEvent inProgressTallyEvent = new IndicatorTallyEvent(TallyStatus.INPROGRESS);
+        EventBusHelper.postStickyEvent(inProgressTallyEvent);
+
+        boolean generated = false;
+        try {
+            IndicatorQueryRepository indicatorQueryRepository = reportingLibrary.indicatorQueryRepository();
+            DailyIndicatorCountRepository dailyIndicatorCountRepository = reportingLibrary.dailyIndicatorCountRepository();
+            IndicatorRepository indicatorRepository = reportingLibrary.indicatorRepository();
+            ReportIndicatorDaoImpl reportIndicatorDao = new ReportIndicatorDaoImpl(
+                    indicatorQueryRepository,
+                    dailyIndicatorCountRepository,
+                    indicatorRepository);
+
+            reportIndicatorDao.generateDailyIndicatorTallies(lastProcessedDate);
+            generated = true;
+        } finally {
+            EventBusHelper.removeStickyEvent(inProgressTallyEvent);
+        }
+
+        if (generated) {
+            EventBusHelper.postEvent(new IndicatorTallyEvent(TallyStatus.COMPLETE));
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Route `ChwIndicatorGeneratingJob.scheduleJob(...)` and `scheduleJobImmediately(...)` through the CHW core `ReportIndicatorGeneratingWorker` WorkManager path.
- Generate report indicator tallies directly inside `ReportIndicatorGeneratingWorker` instead of starting `IndicatorGeneratorIntentService` through a `PendingIntent`.
- Update Jacoco report configuration to the Gradle-compatible `required` / `outputLocation` API so the core artifact can be published for app verification.

## Root Cause

The in-app Reports screen calls `ChwIndicatorGeneratingJob.scheduleJobImmediately(ChwIndicatorGeneratingJob.TAG)`, but that call was still resolving through the deprecated reporting job/service path. On the tested Android 35 build, opening Reports logged the old `IndicatorGeneratorIntentService` path and failed with `RuntimeException: Password has not been set!`, so indicator generation did not reliably run from the UI trigger.

## Validation

- `JAVA_HOME=/Users/ilakozejumanne/Library/Java/JavaVirtualMachines/corretto-17.0.11/Contents/Home ./gradlew :opensrp-chw-core:publishToMavenLocal -x test --console=plain`
- Installed the dependent CHW debug app on `emulator-5554` and opened Reports after login with `Johndeo` / `Afya2026`.
- Verified logcat showed `BaseWorker: Scheduled immediate job with tag 'IndicatorGeneratingJob-Immediate'` and `ReportIndicatorGeneratingWorker: ReportIndicatorGeneratingWorker running`.
- Verified the old `IndicatorGeneratorIntentService` / `Password has not been set!` failure no longer appeared after the patched runtime was installed.
- Pulled the SQLCipher database using the stored SharedPreferences `CURRENT_LOCATION_ID` value as the passphrase and confirmed iCCM indicator tallies were generated in `indicator_daily_tally`.

## Companion Change

A companion CHW app PR fixes iCCM report rendering for derived `jumla` totals.