### PR TITLE
📦 Bump opensrp-client-chw-referral to 1.3.23-NACP-SNAPSHOT

### DIFF
--- a/opensrp-chw-core/build.gradle
+++ b/opensrp-chw-core/build.gradle
@@ -651,7 +651,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'appcompat-v7'
         exclude group: 'id.zelory', module: 'compressor'
     }
-    api('org.smartregister:opensrp-client-chw-referral:1.3.22-NACP-SNAPSHOT@aar') {
+    api('org.smartregister:opensrp-client-chw-referral:1.3.23-NACP-SNAPSHOT@aar') {
         transitive = true
         exclude group: 'org.smartregister', module: 'opensrp-client-core'
         exclude group: 'org.smartregister', module: 'opensrp-client-native-form'

--- a/opensrp-chw-core/src/main/java/org/smartregister/chw/core/presenter/CoreChildProfilePresenter.java
+++ b/opensrp-chw-core/src/main/java/org/smartregister/chw/core/presenter/CoreChildProfilePresenter.java
@@ -108,6 +108,8 @@ public class CoreChildProfilePresenter implements CoreChildProfileContract.Prese
         }
     }
 
+
+
     @Override
     public void onEventSaveComplete(boolean success) {
         // Implement onEventSaveComplete logic here on the presenter child class


### PR DESCRIPTION
## Changes

- 📦 Bump `opensrp-client-chw-referral` dependency from `1.3.22-NACP-SNAPSHOT` to `1.3.23-NACP-SNAPSHOT`
- ♻️ Add blank lines in `CoreChildProfilePresenter` (whitespace-only, no logic change)