### PR TITLE
Add Mother Mentor household enrollment hook

### DIFF
--- a/opensrp-chw-core/build.gradle
+++ b/opensrp-chw-core/build.gradle
@@ -766,6 +766,10 @@ dependencies {
         exclude group: 'org.smartregister', module: 'opensrp-client-core'
         exclude group: 'org.smartregister', module: 'opensrp-client-native-form'
         exclude group: 'org.smartregister', module: 'opensrp-client-configurable-views'
+        exclude group: 'org.smartregister', module: 'opensrp-plan-evaluator'
+        exclude group: 'io.github.bluecodesystems', module: 'opensrp-client-core'
+        exclude group: 'io.github.bluecodesystems', module: 'opensrp-plan-evaluator'
+        exclude group: 'io.github.bluecodesystems', module: 'opensrp-configurable-views'
         exclude group: 'com.android.support', module: 'appcompat-v7'
         exclude group: 'id.zelory', module: 'compressor'
     }

--- a/opensrp-chw-core/src/main/java/org/smartregister/chw/core/activity/CoreFamilyProfileActivity.java
+++ b/opensrp-chw-core/src/main/java/org/smartregister/chw/core/activity/CoreFamilyProfileActivity.java
@@ -113,6 +113,8 @@ public abstract class CoreFamilyProfileActivity extends BaseFamilyProfileActivit
             startFormForEdit();
         } else if (i == R.id.action_hps_enrollment) {
             startHpsHouseholdEnrollment(familyBaseEntityId);
+        } else if (i == R.id.action_mother_mentor_household_enrollment) {
+            startMotherMentorHouseholdEnrollment(familyBaseEntityId);
         } else if (i == R.id.action_remove_member) {
             Intent frm_intent = new Intent(this, getFamilyRemoveMemberClass());
             frm_intent.putExtra(Constants.INTENT_KEY.FAMILY_BASE_ENTITY_ID, getFamilyBaseEntityId());
@@ -435,6 +437,10 @@ public abstract class CoreFamilyProfileActivity extends BaseFamilyProfileActivit
     protected abstract boolean isAncMember(String baseEntityId);
 
     protected abstract void startHpsHouseholdEnrollment(String baseEntityId);
+
+    protected void startMotherMentorHouseholdEnrollment(String baseEntityId) {
+        // Optional module hook.
+    }
 
     protected abstract HashMap<String, String> getAncFamilyHeadNameAndPhone(String baseEntityId);
 

--- a/opensrp-chw-core/src/main/res/menu/profile_menu.xml
+++ b/opensrp-chw-core/src/main/res/menu/profile_menu.xml
@@ -15,6 +15,13 @@
         app:showAsAction="never" />
 
     <item
+        android:id="@+id/action_mother_mentor_household_enrollment"
+        android:enabled="true"
+        android:visible="false"
+        android:title="@string/mother_mentor_household_enrollment"
+        app:showAsAction="never" />
+
+    <item
         android:id="@+id/action_remove_member"
         android:enabled="true"
         android:title="@string/remove_member"
@@ -33,5 +40,4 @@
         app:showAsAction="never" />
 
 </menu>
-
 

--- a/opensrp-chw-core/src/main/res/values-sw/strings.xml
+++ b/opensrp-chw-core/src/main/res/values-sw/strings.xml
@@ -841,6 +841,7 @@
     <string name="refer_to_addo">Unganisha kwenda Duka la Dawa</string>
 
     <string name="hps_enrollment">Usajili kwenye huduma za Afya Jamii (iCCHW)</string>
+    <string name="mother_mentor_household_enrollment">Usajili kwenye huduma za Mama Kinara</string>
     <string name="enter_your_username_to_reset_password">Ingiza jina la mtumiaji kubadili nenosiri:</string>
     <string name="reset_password">Badili Nenosiri</string>
     <string name="back_to_login">Rudi kwenye Login</string>

--- a/opensrp-chw-core/src/main/res/values/strings.xml
+++ b/opensrp-chw-core/src/main/res/values/strings.xml
@@ -897,6 +897,7 @@
     <string name="ayp_out_school_enrollment">AYP Out-school Screening</string>
 
     <string name="mother_mentor_enrollment">Mother Mentor Enrollment</string>
+    <string name="mother_mentor_household_enrollment">Enroll in Mama Kinara services</string>
     <string name="mother_mentor_enroll_iit">Mother Mentor Enroll IIT</string>
     <string name="mother_mentor_enroll_partner">Mother Mentor Enroll Partner</string>
     <string name="mother_mentor_enroll_child_eid">Mother Mentor Enroll Child EID</string>


### PR DESCRIPTION
## Summary
- Adds a hidden family profile menu action for Mama Kinara household enrollment
- Routes the menu selection through an optional CoreFamilyProfileActivity hook
- Adds English and Swahili menu labels

Part of Digital-Square-Tanzania/opensrp-client-chw#947.

## Validation
- git diff --check

Note: :opensrp-chw-core:compileDebugJavaWithJavac resolves the updated Mother Mentor artifact after local publish, then fails on existing Task API mismatches unrelated to this change (TaskRepository.updateTask return type, Task execution date accessors, TaskPriority assignment).

Supersedes #72 so the PR branch uses the ilakoze/ prefix.